### PR TITLE
feat: open role members sheet from mention tap

### DIFF
--- a/Stoat.xcodeproj/project.pbxproj
+++ b/Stoat.xcodeproj/project.pbxproj
@@ -102,6 +102,7 @@
 		17A589FA2C44781F00B9D85A /* AnyTransition.swift in Sources */ = {isa = PBXBuildFile; fileRef = 17A589F92C44781F00B9D85A /* AnyTransition.swift */; };
 		17A6894D2D9590CE00F25C6C /* Array.swift in Sources */ = {isa = PBXBuildFile; fileRef = 17A6894C2D9590CC00F25C6C /* Array.swift */; };
 		17A6894F2D95FC7800F25C6C /* MemberProfileSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 17A6894E2D95FC6A00F25C6C /* MemberProfileSheet.swift */; };
+		17B0501C2E180000A001AA01 /* RoleSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 17B0501C2E180000A001AA02 /* RoleSheet.swift */; };
 		17A7FE372C49DE6F0083B22F /* Member.swift in Sources */ = {isa = PBXBuildFile; fileRef = 17A7FE362C49DE6F0083B22F /* Member.swift */; };
 		17A7FE392C49EBD20083B22F /* Image.swift in Sources */ = {isa = PBXBuildFile; fileRef = 17A7FE382C49EBD20083B22F /* Image.swift */; };
 		17B375812C41FEC300FC7E6E /* Types.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 17DE7DB22BFAEC3F00C99188 /* Types.framework */; };
@@ -288,6 +289,7 @@
 		17A589F92C44781F00B9D85A /* AnyTransition.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnyTransition.swift; sourceTree = "<group>"; };
 		17A6894C2D9590CC00F25C6C /* Array.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Array.swift; sourceTree = "<group>"; };
 		17A6894E2D95FC6A00F25C6C /* MemberProfileSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MemberProfileSheet.swift; sourceTree = "<group>"; };
+		17B0501C2E180000A001AA02 /* RoleSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RoleSheet.swift; sourceTree = "<group>"; };
 		17A7FE362C49DE6F0083B22F /* Member.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Member.swift; sourceTree = "<group>"; };
 		17A7FE382C49EBD20083B22F /* Image.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Image.swift; sourceTree = "<group>"; };
 		17B1A0462BFC471C005D4664 /* Types.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Types.swift; sourceTree = "<group>"; };
@@ -650,6 +652,7 @@
 				17A6894E2D95FC6A00F25C6C /* MemberProfileSheet.swift */,
 				17E28E072AF319D500F6069F /* AddServerSheet.swift */,
 				17CE2E132AE709CE0059FB3A /* UserSheet.swift */,
+				17B0501C2E180000A001AA02 /* RoleSheet.swift */,
 				17BC476A2B9CB51200A593DA /* ShareInviteSheet.swift */,
 				173F16262C3C22540009FDF9 /* ServerInfoSheet.swift */,
 			);
@@ -1174,6 +1177,7 @@
 				17BF54D12B17B24200178866 /* LanguageSettings.swift in Sources */,
 				17E019CD2AF136B100AB4663 /* PresenceIndicator.swift in Sources */,
 				17A6894F2D95FC7800F25C6C /* MemberProfileSheet.swift in Sources */,
+				17B0501C2E180000A001AA01 /* RoleSheet.swift in Sources */,
 				17CCCF702ADA17B600D78D7A /* Utils.swift in Sources */,
 				172F2D032C22ED5C00948C00 /* Collection.swift in Sources */,
 				178E26BC2B1542820015CAC7 /* PageToolbar.swift in Sources */,

--- a/Stoat/Components/Contents.swift
+++ b/Stoat/Components/Contents.swift
@@ -878,15 +878,50 @@ class EmojiView: UIView {
     }
 }
 
+class RoleMentionView: UIView {
+    var nameView: UILabel!
+
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        createSubViews()
+    }
+
+    init() {
+        super.init(frame: .zero)
+        createSubViews()
+    }
+
+    private func createSubViews() {
+        self.nameView = UILabel()
+        self.nameView.numberOfLines = 1
+
+        addSubview(nameView)
+
+        nameView.snp.makeConstraints { make in
+            make.leading.equalTo(self.snp.leading).offset(6)
+            make.trailing.equalTo(self.snp.trailing).offset(-6)
+            make.centerY.equalTo(self.snp.centerY)
+        }
+
+        self.snp.makeConstraints { make in
+            make.height.equalTo(nameView.snp.height)
+        }
+    }
+
+    required init(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+}
+
 class UserMentionView: UIView {
     var imageView: UIImageView!
     var nameView: UILabel!
-    
+
     override init(frame: CGRect) {
         super.init(frame: frame)
         createSubViews(imageHeight: frame.height)
     }
-    
+
     init(imageHeight: CGFloat) {
         super.init(frame: .zero)
         createSubViews(imageHeight: imageHeight)
@@ -1040,13 +1075,58 @@ let defaultParagraphStyle: NSParagraphStyle = {
 
 class UserMentionTapHandler: NSObject {
     let callback: () -> Void
-    
+
     init(callback: @escaping () -> Void) {
         self.callback = callback
     }
-    
+
     @objc func handle(_: UITapGestureRecognizer) {
         callback()
+    }
+}
+
+class RoleMentionTapHandler: NSObject {
+    let callback: () -> Void
+
+    init(callback: @escaping () -> Void) {
+        self.callback = callback
+    }
+
+    @objc func handle(_: UITapGestureRecognizer) {
+        callback()
+    }
+}
+
+final class TappableViewAttachmentProvider: NSObject, TextAttachedViewProvider {
+    let view: UIView
+
+    init(view: UIView) {
+        self.view = view
+        super.init()
+    }
+
+    func instantiateView(for attachment: SubviewTextAttachment, in behavior: SubviewAttachingTextViewBehavior) -> UIView {
+        return self.view
+    }
+
+    func bounds(for attachment: SubviewTextAttachment, textContainer: NSTextContainer?, proposedLineFragment lineFrag: CGRect, glyphPosition position: CGPoint) -> CGRect {
+        return attachment.bounds
+    }
+}
+
+final class TappableSubviewTextAttachment: SubviewTextAttachment {
+    let onTap: () -> Void
+
+    init(view: UIView, onTap: @escaping () -> Void) {
+        self.onTap = onTap
+        super.init(viewProvider: TappableViewAttachmentProvider(view: view))
+        let fitting = view.systemLayoutSizeFitting(UIView.layoutFittingCompressedSize)
+        let size = (fitting.width > 1e-3 && fitting.height > 1e-3) ? fitting : view.bounds.size
+        self.bounds = CGRect(origin: .zero, size: size)
+    }
+
+    required init?(coder aDecoder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
     }
 }
 
@@ -1060,7 +1140,6 @@ struct InnerContents: UIViewRepresentable {
     
     @Binding var content: String
     
-    @State var handlers: [UserMentionTapHandler] = []
         
     var fontSize: CGFloat
     var contentFont: UIFont
@@ -1110,7 +1189,51 @@ struct InnerContents: UIViewRepresentable {
         textview.textContainerInset = .zero
         textview.setContentCompressionResistancePriority(.defaultLow, for: .horizontal)
 
+        let tap = UITapGestureRecognizer(target: context.coordinator, action: #selector(Coordinator.handleTap(_:)))
+        tap.delegate = context.coordinator
+        tap.cancelsTouchesInView = false
+        textview.addGestureRecognizer(tap)
+
         return textview
+    }
+
+    func makeCoordinator() -> Coordinator {
+        Coordinator()
+    }
+
+    final class Coordinator: NSObject, UIGestureRecognizerDelegate {
+        @objc func handleTap(_ recognizer: UITapGestureRecognizer) {
+            guard let textview = recognizer.view as? UITextView else { return }
+
+            let point = recognizer.location(in: textview)
+            let textLocation = textview.convertPointToTextContainer(point)
+            let layoutManager = textview.layoutManager
+
+            guard textview.textStorage.length > 0 else { return }
+
+            let charIndex = layoutManager.characterIndex(
+                for: textLocation,
+                in: textview.textContainer,
+                fractionOfDistanceBetweenInsertionPoints: nil
+            )
+
+            guard charIndex >= 0, charIndex < textview.textStorage.length else { return }
+
+            if let attachment = textview.textStorage.attribute(
+                .attachment,
+                at: charIndex,
+                effectiveRange: nil
+            ) as? TappableSubviewTextAttachment {
+                attachment.onTap()
+            }
+        }
+
+        func gestureRecognizer(
+            _ gestureRecognizer: UIGestureRecognizer,
+            shouldRecognizeSimultaneouslyWith otherGestureRecognizer: UIGestureRecognizer
+        ) -> Bool {
+            return true
+        }
     }
     
     func fixAttributedStringStyling(for string: NSMutableAttributedString) {
@@ -1134,10 +1257,6 @@ struct InnerContents: UIViewRepresentable {
     }
     
     func updateUIView(_ textview: UIViewType, context: Context) {
-        DispatchQueue.main.async {
-            handlers.removeAll()
-        }
-        
         let attrString = try! NSMutableAttributedString(markdown: content.data(using: .utf8)!, options: .init(allowsExtendedAttributes: true, interpretedSyntax: .full, failurePolicy: .returnPartiallyParsedIfPossible))
         
         fixAttributedStringStyling(for: attrString)
@@ -1292,20 +1411,47 @@ struct InnerContents: UIViewRepresentable {
         
         for match in attrString.string.matches(of: /<%(\w{26})>/).reversed() {
             let id = match.output.1
-            
-            if let role = currentServer?.roles?[String(id)] {
+
+            if let server = currentServer, let role = server.roles?[String(id)] {
                 let lowerInt = match.range.lowerBound.utf16Offset(in: attrString.string)
                 let lower = match.range.lowerBound
                 let upper = match.range.upperBound
-                
+
                 let globalRange = Range(uncheckedBounds: (lower, upper))
-                
-                var currentAttrs = attrString.attributes(at: lowerInt, effectiveRange: nil)
-                
-                currentAttrs[.foregroundColor] = viewState.theme.accent.uiColor  // TODO: somehow do the role colour - current parser emmits swiftui colours
-                
+
+                let currentAttrs = attrString.attributes(at: lowerInt, effectiveRange: nil)
+                let currentFont = (currentAttrs[.font] ?? contentFont) as! UIFont
+
                 attrString.deleteCharacters(in: NSRange(globalRange, in: attrString.string))
-                attrString.insert(NSAttributedString(string: "@\(role.name)", attributes: currentAttrs), at: lowerInt)
+
+                let view = RoleMentionView()
+                view.backgroundColor = viewState.theme.background2.uiColor
+                view.layer.cornerRadius = currentFont.pointSize / 2
+
+                view.nameView.text = "@\(role.name)"
+                view.nameView.font = .boldSystemFont(ofSize: currentFont.pointSize)
+                let color: UIColor
+                if let roleColorHex = role.colour {
+                    let (r, g, b, a) = parseHex(hex: roleColorHex)
+                    color = UIColor(
+                        red: r,
+                        green: g,
+                        blue: b,
+                        alpha: a
+                    )
+                } else {
+                    color = viewState.theme.accent.uiColor
+                }
+                view.nameView.textColor = color
+
+                let serverId = server.id
+                let attachment = TappableSubviewTextAttachment(view: view) {
+                    viewState.openRoleSheet(role: role, serverId: serverId)
+                }
+
+                textview.addSubview(view)
+
+                attrString.insert(NSAttributedString(attachment: attachment), at: lowerInt)
             }
         }
         
@@ -1340,23 +1486,14 @@ struct InnerContents: UIViewRepresentable {
                                 
                 view.nameView.text = member?.nickname ?? user.display_name ?? user.username
                 view.nameView.font = .boldSystemFont(ofSize: currentFont.pointSize)
-                
-                view.isUserInteractionEnabled = true
-                
-                let handler = UserMentionTapHandler {
+
+                let attachment = TappableSubviewTextAttachment(view: view) {
                     viewState.openUserSheet(user: user, member: member)
                 }
-                
-                DispatchQueue.main.async {
-                    handlers.append(handler)
-                }
-                
-                let recogniser = UITapGestureRecognizer(target: handler, action: #selector(UserMentionTapHandler.handle(_:)))
-                view.addGestureRecognizer(recogniser)
 
                 textview.addSubview(view)
-                
-                attrString.insert(NSAttributedString(attachment: SubviewTextAttachment(view: view)), at: lowerInt)
+
+                attrString.insert(NSAttributedString(attachment: attachment), at: lowerInt)
             }
         }
         

--- a/Stoat/Components/Sheets/RoleSheet.swift
+++ b/Stoat/Components/Sheets/RoleSheet.swift
@@ -1,0 +1,116 @@
+//
+//  RoleSheet.swift
+//  Stoat
+//
+//  Lists server members who have the tapped role.
+//
+
+import SwiftUI
+import Types
+
+struct RoleSheet: View {
+    @EnvironmentObject var viewState: ViewState
+    @Environment(\.dismiss) private var dismiss
+
+    let role: Role
+    let serverId: String
+
+    private var roleColour: AnyShapeStyle {
+        if let colour = role.colour {
+            return parseCSSColorToShapeStyle(currentTheme: viewState.theme, input: colour)
+        } else {
+            return AnyShapeStyle(viewState.theme.accent)
+        }
+    }
+
+    private var membersWithRole: [Member] {
+        guard let serverMembers = viewState.members[serverId] else { return [] }
+
+        return serverMembers.values
+            .filter { $0.roles?.contains(role.id) ?? false }
+            .sorted { lhs, rhs in
+                let lhsName = displayName(for: lhs)
+                let rhsName = displayName(for: rhs)
+                return lhsName.localizedCaseInsensitiveCompare(rhsName) == .orderedAscending
+            }
+    }
+
+    private func displayName(for member: Member) -> String {
+        if let nickname = member.nickname { return nickname }
+        if let user = viewState.users[member.id.user] {
+            return user.display_name ?? user.username
+        }
+        return member.id.user
+    }
+
+    var body: some View {
+        NavigationStack {
+            List {
+                Section {
+                    ForEach(membersWithRole, id: \.id) { member in
+                        if let user = viewState.users[member.id.user] {
+                            Button {
+                                dismiss()
+                                viewState.openUserSheet(user: user, member: member)
+                            } label: {
+                                HStack(spacing: 12) {
+                                    Avatar(user: user, member: member, width: 32, height: 32, withPresence: true)
+
+                                    VStack(alignment: .leading, spacing: 2) {
+                                        Text(member.nickname ?? user.display_name ?? user.username)
+                                            .foregroundStyle(viewState.theme.foreground)
+                                            .lineLimit(1)
+
+                                        if member.nickname != nil || user.display_name != nil {
+                                            Text(verbatim: "@\(user.username)")
+                                                .font(.caption)
+                                                .foregroundStyle(viewState.theme.foreground2)
+                                                .lineLimit(1)
+                                        }
+                                    }
+
+                                    Spacer()
+                                }
+                            }
+                        }
+                    }
+                } header: {
+                    HStack(spacing: 8) {
+                        Circle()
+                            .foregroundStyle(roleColour)
+                            .frame(width: 12, height: 12)
+
+                        Text(verbatim: role.name)
+                            .foregroundStyle(roleColour)
+
+                        Spacer()
+
+                        Text("\(membersWithRole.count)")
+                            .foregroundStyle(viewState.theme.foreground2)
+                    }
+                    .textCase(nil)
+                    .padding(.vertical, 4)
+                }
+                .listRowBackground(viewState.theme.background2)
+            }
+            .background(viewState.theme.background)
+            .scrollContentBackground(.hidden)
+            .navigationTitle(role.name)
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .topBarTrailing) {
+                    Button("Done") { dismiss() }
+                }
+            }
+            .overlay {
+                if membersWithRole.isEmpty {
+                    ContentUnavailableView(
+                        "No members",
+                        systemImage: "person.slash",
+                        description: Text("No loaded members have this role.")
+                    )
+                }
+            }
+        }
+    }
+}

--- a/Stoat/StoatApp.swift
+++ b/Stoat/StoatApp.swift
@@ -264,6 +264,9 @@ struct MainApp: View {
         .sheet(item: $viewState.currentUserSheet) { (v) in
             UserSheet(user: v.user, member: v.member)
         }
+        .sheet(item: $viewState.currentRoleSheet) { data in
+            RoleSheet(role: data.role, serverId: data.serverId)
+        }
     }
 }
 

--- a/Stoat/ViewState.swift
+++ b/Stoat/ViewState.swift
@@ -127,6 +127,13 @@ struct UserMaybeMember: Identifiable {
     var id: String { user.id }
 }
 
+struct RoleSheetData: Identifiable, Equatable {
+    var role: Role
+    var serverId: String
+
+    var id: String { "\(serverId):\(role.id)" }
+}
+
 @MainActor
 public class ViewState: ObservableObject {
     static var shared: ViewState? = nil
@@ -251,6 +258,7 @@ public class ViewState: ObservableObject {
     @Published var isOnboarding: Bool = false
     @Published var unreads: [String: Unread] = [:]
     @Published var currentUserSheet: UserMaybeMember? = nil
+    @Published var currentRoleSheet: RoleSheetData? = nil
     @Published var currentVoiceChannel: String? = nil
     @Published var currentVoice: Room? = nil
     @Published var atTopOfChannel: Set<String> = []
@@ -1283,6 +1291,10 @@ public class ViewState: ObservableObject {
     
     func openUserSheet(user: Types.User, member: Member? = nil) {
         currentUserSheet = UserMaybeMember(user: user, member: member)
+    }
+
+    func openRoleSheet(role: Role, serverId: String) {
+        currentRoleSheet = RoleSheetData(role: role, serverId: serverId)
     }
     
     public var openServer: Server? {


### PR DESCRIPTION
## Summary

- Tapping a role mention (`<%roleId>`, rendered as `@RoleName`) now presents a sheet listing the server members who hold that role. Each row routes into the existing `UserSheet` for drill-down.
- Fixed a related bug where user mention pills also failed to react to taps. Root cause: the `UITextView` in `InnerContents` intercepts touches via its internal gestures, so per-subview `UITapGestureRecognizer`s installed on `UserMentionView` / `RoleMentionView` never fired.
- Reworked tap dispatch to live on the textview itself: a `Coordinator` (`UIGestureRecognizerDelegate`, `shouldRecognizeSimultaneouslyWith` → true) hit-tests via `layoutManager.characterIndex(for:in:fractionOfDistanceBetweenInsertionPoints:)`, looks up the attachment at that character, and invokes a closure carried by a new `TappableSubviewTextAttachment` (subclass of `SubviewTextAttachment`).

## Scope notes

- Active only when the experimental `customMarkdown` flag is ON (Settings → Misc → Experiments → "Enable Custom Markdown"). The default `Text(verbatim:)` path does not parse role mentions; that remains out of scope for this PR.
- `viewState.members[serverId]` is filtered against currently-loaded members; very large servers with un-paginated members may show an incomplete list. Out of scope.
- Role colour is still rendered via `viewState.theme.accent.uiColor` in the pill (TODO from existing code); the sheet header uses `parseCSSColorToShapeStyle` so the actual role colour is visible there.

## Files

- `Stoat/Components/Sheets/RoleSheet.swift` (new)
- `Stoat/ViewState.swift` — `RoleSheetData`, `currentRoleSheet`, `openRoleSheet(role:serverId:)`
- `Stoat/Components/Contents.swift` — `RoleMentionView`, `TappableSubviewTextAttachment`, `Coordinator` with textview-level tap handler, role mention loop rewritten to use the new attachment
- `Stoat/StoatApp.swift` — `.sheet(item: \$viewState.currentRoleSheet)` wiring
- `Stoat.xcodeproj/project.pbxproj` — register `RoleSheet.swift` (4 hunks)

## Test plan

- [x] Build for iOS Simulator and verify no compiler errors
- [x] Enable Settings → Experiments → Custom Markdown
- [x] In a server channel, send / receive a message containing a role mention; tap the `@RoleName` pill → role members sheet opens
- [x] Tap a member row → existing `UserSheet` opens
- [x] Tap a user mention pill in another message → existing `UserSheet` opens (regression check for the touch-handling refactor)
- [x] Verify channel mention pills, emoji, message-link pills, and timestamps continue to render correctly